### PR TITLE
Alter the outputFileReading setting to be relative to servlet context

### DIFF
--- a/grails-app/controllers/org/restapidoc/RestApiDocController.groovy
+++ b/grails-app/controllers/org/restapidoc/RestApiDocController.groovy
@@ -18,9 +18,14 @@ class RestApiDocController {
     }
 
     def api() {
-        //InputStream doc = this.class.classLoader.getResourceAsStream(grailsApplication.mergedConfig.grails.plugins.restapidoc.outputFile)
-        File docFile = new File(grailsApplication.mergedConfig.grails.plugins.restapidoc.outputFileReading)
-        log.info "Read doc file ${docFile.absolutePath}"
-        render(docFile.text)
+        def input
+        try {
+            input = servletContext.getResourceAsStream(grailsApplication.mergedConfig.grails.plugins.restapidoc.outputFileReading)
+            render(input.text)
+        }
+        finally {
+            input.close()
+        }
+
     }
 }


### PR DESCRIPTION
For issue #12, I thought the plugin should use the servlet content when reading the JSON file.