### PR TITLE
Place rest-api-doc content within a div with CSS class for style

### DIFF
--- a/grails-app/views/restApiDoc/index.gsp
+++ b/grails-app/views/restApiDoc/index.gsp
@@ -10,30 +10,32 @@
         <meta name="layout" content="${layout}">
     </head>
     <body>
-        <div class="navbar navbar-fixed-top navbar-inverse">
-            <div class="container-fluid">
-                <div class="navbar-header"><a class="navbar-brand" href="#">RestApiDoc</a></div>
-                <form class="navbar-form navbar-left">
-                    <input id="jsondocfetch" class="form-control" type="text" placeholder="Insert here the RestApiDoc URL" autocomplete="off">
-                    <button id="getDocButton" type="button" class="btn btn-default">Get documentation</button>
-                </form>
+        <div class="rest-api-content">
+            <div class="navbar navbar-fixed-top navbar-inverse">
+                <div class="container-fluid">
+                    <div class="navbar-header"><a class="navbar-brand" href="#">RestApiDoc</a></div>
+                    <form class="navbar-form navbar-left">
+                        <input id="jsondocfetch" class="form-control" type="text" placeholder="Insert here the RestApiDoc URL" autocomplete="off">
+                        <button id="getDocButton" type="button" class="btn btn-default">Get documentation</button>
+                    </form>
+                </div>
             </div>
-        </div>
-
-        <div class="container-fluid">
-            <div class="row">
-                <div class="col-sm-3 col-md-3">
-                    <div id="maindiv" style="display:none;"></div>
-                    <div id="apidiv" style="display:none;"></div>
-                    <div id="objectdiv" style="display:none;"></div>
-                </div>
-
-                <div class="col-sm-5 col-md-5">
-                    <div id="content"></div>
-                </div>
-
-                <div class="col-sm-4 col-md-4">
-                    <div id="testContent"></div>
+    
+            <div class="container-fluid">
+                <div class="row">
+                    <div class="col-sm-3 col-md-3">
+                        <div id="maindiv" style="display:none;"></div>
+                        <div id="apidiv" style="display:none;"></div>
+                        <div id="objectdiv" style="display:none;"></div>
+                    </div>
+    
+                    <div class="col-sm-5 col-md-5">
+                        <div id="content"></div>
+                    </div>
+    
+                    <div class="col-sm-4 col-md-4">
+                        <div id="testContent"></div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/web-app/css/restapidoc/restapidoc.css
+++ b/web-app/css/restapidoc/restapidoc.css
@@ -1,4 +1,4 @@
-body {
+.rest-api-content {
     padding-top: 60px;
     padding-bottom: 40px;
 }


### PR DESCRIPTION
For Issue #53, I placed rest-api content within a div, so we can apply specific styling without altering other the style for other 'body' elements.