### PR TITLE
Use the base url to construct a default doc_url parameter

### DIFF
--- a/web-app/js/restapidoc/restapidoc.js
+++ b/web-app/js/restapidoc/restapidoc.js
@@ -232,6 +232,16 @@ $(document).ready(function() {
         $('#jsondocfetch').attr('value', parameters['doc_url']);
         $('#getDocButton').click();
     }
+    else {
+    	// Default to the url of the host server
+    	// Ex. http://.../restApiDoc/?doc_url=http://.../restApiDoc/api#
+    	
+    	// First, strip any special characters or query string; then, add back the controller name
+    	var docURL = document.URL.split('restApiDoc')[0].concat('restApiDoc');
+    	
+    	// Now, build the default URL
+    	window.location = docURL.concat('?doc_url=').concat(docURL).concat('/api#');
+    }
 
     $(document).on("click", "#selectStringParameters", function(event) {
         event.preventDefault();


### PR DESCRIPTION
I thought it would be nice to generate a default doc_url using the host server, as opposed to typing in the entire thing.